### PR TITLE
Remove several special chars from comments which prevented building b…

### DIFF
--- a/src/ahrd/model/BlastResult.java
+++ b/src/ahrd/model/BlastResult.java
@@ -87,7 +87,7 @@ public class BlastResult implements Comparable<BlastResult> {
 	private Protein protein;
 
 	/**
-	 * Makes a double string representation parseable by Double.parseDouble(…).
+	 * Makes a double string representation parseable by Double.parseDouble
 	 * 
 	 * @param input
 	 * @return String
@@ -282,7 +282,7 @@ public class BlastResult implements Comparable<BlastResult> {
 	 * Adds the sequence length and Human Readable Description (HRD) to all
 	 * matching BlastHits found in the argument Map 'blastResults'. Afterwards
 	 * the respective BlastResult instances are added to their respective
-	 * Proteins. See function <code>generateHRDCandidateForProtein(…)</code> for
+	 * Proteins. See function <code>generateHRDCandidateForProtein</code> for
 	 * more details.
 	 * 
 	 * @param blastResults
@@ -304,7 +304,7 @@ public class BlastResult implements Comparable<BlastResult> {
 	 * and human readable descriptions of those Proteins that are Hits
 	 * (Subjects) in the argument blastResults. Each time such a Hit is found
 	 * the mentioned measurements are set in the respective instance of
-	 * BlastResult and subsequently the method 'Protein.addBlastResult(…)' is
+	 * BlastResult and subsequently the method 'Protein.addBlastResult' is
 	 * invoked.
 	 * 
 	 * @param proteinDb

--- a/src/ahrd/model/EvaluationScoreCalculator.java
+++ b/src/ahrd/model/EvaluationScoreCalculator.java
@@ -123,7 +123,7 @@ public class EvaluationScoreCalculator {
 	 * Recall is identical with the True-Positive-Rate: recall (rc) :=
 	 * true-positives / #reference-tokens
 	 * 
-	 * f-beta-score := (1+beta²) * (pr * rc) / (beta²*pr + rc)
+	 * f-beta-score := (1+beta^2) * (pr * rc) / ((beta^2)*pr + rc)
 	 * 
 	 * @param assignedTkns
 	 *            - Tokens of the Description assigned by AHRD or a


### PR DESCRIPTION
…y ant on

my platform (issue#6). in BlastResult the chars printed as "..." for function arguments.
In EvaluationScoreCalculator they were exponents "2" and I changed them to "^2".