### PR TITLE
fix windows newline parse error for fasta headers with no extra white…

### DIFF
--- a/src/ahrd/model/Protein.java
+++ b/src/ahrd/model/Protein.java
@@ -68,7 +68,7 @@ public class Protein {
 
 	public static Protein constructFromFastaEntry(String fastaEntry)
 			throws MissingAccessionException {
-		String[] fasta_data = fastaEntry.split("\n");
+		String[] fasta_data = fastaEntry.split("\r?\n");
 		String accession = fasta_data[0].split(" ")[0];
 		if (accession == null || accession.equals("")) {
 			throw new MissingAccessionException(


### PR DESCRIPTION
Fix for issue #10, add /r to one split pattern. Otherwise fasta headers using /r/n and no additional whitespace end up with an extra /r attached to the accession. 