### PR TITLE
regex debugging

### DIFF
--- a/src/ahrd/controller/Settings.java
+++ b/src/ahrd/controller/Settings.java
@@ -99,6 +99,7 @@ public class Settings implements Cloneable {
 	public static final String PREFER_REFERENCE_WITH_GO_ANNOS_KEY = "prefer_reference_with_go_annos";
 	public static final String EVALUATE_VALID_TAKENS_KEY = "evaluate_valid_tokens";
 	public static final String DEFAULT_LINE_SEP = "(\r|\n)+"; 
+	public static final String DEBUG_REGEX_KEY = "debug_regex"; 
 
 	/**
 	 * Fields:
@@ -115,6 +116,7 @@ public class Settings implements Cloneable {
 	private String pathToInterproResults;
 	private String pathToGeneOntologyResults;
 	private String pathToOutput;
+	private Boolean debugRegex = false;
 	/**
 	 * File to write the AHRD-Scores of each BlastHit's Description into, if
 	 * requested.
@@ -266,6 +268,7 @@ public class Settings implements Cloneable {
 		setWriteBestBlastHitsToOutput(Boolean.parseBoolean((String) input.get(WRITE_BEST_BLAST_HITS_TO_OUTPUT)));
 		setWriteScoresToOutput(Boolean.parseBoolean((String) input.get(WRITE_SCORES_TO_OUTPUT)));
 		setOutputFasta(Boolean.parseBoolean((String) input.get(OUTPUT_FASTA_KEY)));
+		setDebugRegex(Boolean.parseBoolean((String) input.get(DEBUG_REGEX_KEY)));
 		// Generate the Blacklists and Filters for each Blast-Database from
 		// their appropriate files:
 		for (String blastDatabaseName : getBlastDatabases()) {
@@ -926,4 +929,12 @@ public class Settings implements Cloneable {
 	public void setReferencesTokenBlacklist(List<String> referencesTokenBlacklist) {
 		this.referencesTokenBlacklist = referencesTokenBlacklist;
 	}
+	public boolean debugRegex() {
+		return this.debugRegex;
+	} 
+	public void setDebugRegex(Boolean debug) {
+		if (debug != null) {
+			this.debugRegex = debug;
+		}
+	} 
 }

--- a/src/ahrd/model/BlastResult.java
+++ b/src/ahrd/model/BlastResult.java
@@ -345,17 +345,44 @@ public class BlastResult implements Comparable<BlastResult> {
 								+ Settings.FASTA_HEADER_REGEX_KEY
 								+ " to provide a regular expression that matches ALL FASTA headers in Blast database '"
 								+ blastDbName + "'.");
-					} else if (blastResults.containsKey(m.group(FASTA_PROTEIN_HEADER_ACCESSION_GROUP_NAME).trim())) {
-						// Found the next Blast HIT:
-						acc = m.group(FASTA_PROTEIN_HEADER_ACCESSION_GROUP_NAME).trim();
-						hrd = m.group(FASTA_PROTEIN_HEADER_DESCRIPTION_GROUP_NAME).trim();
-						// Following lines, until the next header, contain
-						// information to be collected:
-						hit = true;
 					} else {
-						// Found a Protein in the FASTA database, that is of no
-						// relevance within this context:
-						hit = false;
+						acc = m.group(FASTA_PROTEIN_HEADER_ACCESSION_GROUP_NAME); 
+						if (acc == null) {
+							System.err.println("ERROR:Unable to parse accession from header line\n" + str + "\n" +
+								"using regex pattern:" + getSettings().getFastaHeaderRegex(blastDbName).toString() );
+							continue;
+						}
+						else if (acc.trim() == "") {
+							System.err.println("ERROR:Parsed empty accession from header line\n" + str + "\n" +
+								"using regex pattern:" + getSettings().getFastaHeaderRegex(blastDbName).toString() );
+							continue;
+						}
+						hrd = m.group(FASTA_PROTEIN_HEADER_DESCRIPTION_GROUP_NAME);
+						if (hrd == null)
+						{
+							if (getSettings().debugRegex()) {
+								System.err.println("Parsed accession: " + acc );
+							}
+							System.err.println("ERROR:Unable to parse description from header line\n" + str + "\n" +
+								"using regex pattern:" + getSettings().getFastaHeaderRegex(blastDbName).toString());
+							continue;
+						}
+						acc = acc.trim();
+						hrd = hrd.trim();
+						if (getSettings().debugRegex()) {
+							System.err.println("Parsed accession: " + acc );
+							System.err.println("Parsed description: " + hrd );
+						}
+						if (blastResults.containsKey(acc)) {
+							// Found the next Blast HIT:
+							// Following lines, until the next header, contain
+							// information to be collected:
+							hit = true;
+						} else {
+							// Found a Protein in the FASTA database, that is of no
+							// relevance within this context:
+							hit = false;
+						}
 					}
 				} else if (hit) {
 					// Process non header-line, if and only if, we are reading


### PR DESCRIPTION
1. Added yml file option debug_regex. If true, it causes printout of matched accession and description terms. 

2. Slight rearrangement of regex parsing to produce meaningful error messages in cases where the regex matches overall but one of the fields (accession or description) does not match. Mainly this means moving the trim() operations so as to not produce null pointers, and also printing appropriate error messages. 